### PR TITLE
fix stof error

### DIFF
--- a/include/SE2posemanager.hpp
+++ b/include/SE2posemanager.hpp
@@ -22,14 +22,24 @@ void loadGTPoses(const std::string &gt_path, std::unordered_map<int64, std::vect
     std::ifstream ifs(gt_path);
     std::string   line;
     // If the first line consists of text, below line should be uncommented
-//    std::getline(ifs, line);
+    // std::getline(ifs, line);
+
     while (std::getline(ifs, line)) {
+        if (line.empty()) continue;
+        float x,y,yaw;
         std::vector<std::string> words;
         boost::split(words, line, boost::is_any_of(","));
+
+        if (words.size() < 4) {
+            std::cerr << "Skipping invalid line: " << line << std::endl;
+            continue;
+        }
         int64              timestamp    = stoll(words[0]);
-        std::vector<float> parsed_xyyaw = {stof(words[1]), stof(words[3]), stof(words[3])};
+
+        std::vector<float> parsed_xyyaw = {stod(words[1]), stod(words[2]), stod(words[3])};
         gt_rel[timestamp] = parsed_xyyaw;
     }
+
     std::cout << "Total " << gt_rel.size() << " GT rel. poses are loaded" << std::endl;
     if (gt_rel.size() == 0) {
         throw invalid_argument("Some parameters seem to be wrong! Load GT failed!");

--- a/include/SE2posemanager.hpp
+++ b/include/SE2posemanager.hpp
@@ -26,13 +26,12 @@ void loadGTPoses(const std::string &gt_path, std::unordered_map<int64, std::vect
 
     while (std::getline(ifs, line)) {
         if (line.empty()) continue;
-        float x,y,yaw;
         std::vector<std::string> words;
         boost::split(words, line, boost::is_any_of(","));
 
         if (words.size() < 4) {
             std::cerr << "Skipping invalid line: " << line << std::endl;
-            continue;
+            throw std::logic_error("Invalid line detected from GT dataset!");
         }
         int64              timestamp    = stoll(words[0]);
 

--- a/launch/run_orora.launch
+++ b/launch/run_orora.launch
@@ -2,8 +2,8 @@
     <!-- use your path -->
     <rosparam command="load" file="$(find orora)/config/orora_params.yaml" />
 
-    <arg name="seq_dir" default="" />
-    <arg name="do_slam" default="false" />
+    <arg name="seq_dir" default="/root/dataset/DCC01" />
+    <arg name="do_slam" default="true" />
 
     <param name="seq_dir" type="string" value="$(arg seq_dir)" />
     <param name="do_slam" type="bool" value="$(arg do_slam)" />

--- a/launch/run_orora.launch
+++ b/launch/run_orora.launch
@@ -2,8 +2,8 @@
     <!-- use your path -->
     <rosparam command="load" file="$(find orora)/config/orora_params.yaml" />
 
-    <arg name="seq_dir" default="/root/dataset/DCC01" />
-    <arg name="do_slam" default="true" />
+    <arg name="seq_dir" default="" />
+    <arg name="do_slam" default="false" />
 
     <param name="seq_dir" type="string" value="$(arg seq_dir)" />
     <param name="do_slam" type="bool" value="$(arg do_slam)" />


### PR DESCRIPTION
Hi , @LimHyungTae 

Thank you for all your amazing contributions! I’ve been following your work on GitHub, LinkedIn, and through your papers.

While running ORORA with the Mulran dataset (sequence DDC01), I encountered an error in the `loadGTPoses` function within `include/SE2posemanager.hpp`. The error was:

```
terminate called after throwing an instance of 'std::out_of_range' what(): stof
```
After some investigation, I discovered that the issue occurs because the `radar_odometry.csv` file contains the value `1.43493e-42`. To handle this properly, I changed the conversion from `stof` to `stod`.

Additionally, I noticed that the vector `parsed_xyyaw` was mistakenly parsing the yaw value twice (using `words[3]` for both y and yaw). I corrected it so that it now properly reads x, y, and yaw:

```
std::vector<float> parsed_xyyaw = {stod(words[1]), stod(words[2]), stod(words[3])};
```
I’ve also added a few safety functions to improve robustness.

Thank you for taking the time to review these changes. I’m really excited to contribute to a codebase by someone I truly admire!

Best regards,
Junseo Min